### PR TITLE
#29 сделал возможность составного ключа с генерацией long integer внутри

### DIFF
--- a/src/main/java/apps/amaralus/qa/platform/dataset/model/AliasModel.java
+++ b/src/main/java/apps/amaralus/qa/platform/dataset/model/AliasModel.java
@@ -1,19 +1,29 @@
 package apps.amaralus.qa.platform.dataset.model;
 
+import apps.amaralus.qa.platform.rocksdb.key.CompoundKey;
 import apps.amaralus.qa.platform.rocksdb.sequence.GeneratedSequence;
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.keyvalue.annotation.KeySpace;
 
 @Data
 @KeySpace("alias")
-//todo сделать составной ключ name+project
 public class AliasModel {
+
     @Id
     @GeneratedSequence("alias-sequence")
-    private long id;
+    private Key key;
     private String name;
     private long dataset;
     private String propertyName;
-    private String project;
+
+    @Getter
+    @Setter
+    @CompoundKey
+    public static final class Key {
+        long id;
+        String project;
+    }
 }

--- a/src/main/java/apps/amaralus/qa/platform/dataset/repository/AliasRepository.java
+++ b/src/main/java/apps/amaralus/qa/platform/dataset/repository/AliasRepository.java
@@ -8,9 +8,9 @@ import java.util.Optional;
 
 public interface AliasRepository extends KeyValueRepository<AliasModel, Long> {
 
-    List<AliasModel> findAllByProject(String project);
+    List<AliasModel> findAllByKey_Project(String project);
 
-    Optional<AliasModel> findByNameAndProject(String name, String project);
+    Optional<AliasModel> findByNameAndKey_Project(String name, String project);
 
-    List<AliasModel> findAllByNameAndProject(String name, String project);
+    List<AliasModel> findAllByNameAndKey_Project(String name, String project);
 }

--- a/src/main/java/apps/amaralus/qa/platform/dataset/service/AliasService.java
+++ b/src/main/java/apps/amaralus/qa/platform/dataset/service/AliasService.java
@@ -32,7 +32,7 @@ public class AliasService {
 
     public Alias updateAliasName(String newName, String oldName, String project) {
 
-        var alias = aliasRepository.findByNameAndProject(oldName, project)
+        var alias = aliasRepository.findByNameAndKey_Project(oldName, project)
                 .map(aliasModel -> {
                     aliasModel.setName(newName);
                     return aliasRepository.save(aliasModel);
@@ -43,15 +43,15 @@ public class AliasService {
     }
 
     public void deleteAliasByName(String name, String project) {
-        aliasRepository.deleteAll(aliasRepository.findAllByNameAndProject(name, project));
+        aliasRepository.deleteAll(aliasRepository.findAllByNameAndKey_Project(name, project));
     }
 
     public void deleteAllByProject(String project) {
-        aliasRepository.deleteAll(aliasRepository.findAllByProject(project));
+        aliasRepository.deleteAll(aliasRepository.findAllByKey_Project(project));
     }
 
     public Optional<Alias> getAliasByName(String aliasName, String project) {
-        return aliasRepository.findByNameAndProject(aliasName, project)
+        return aliasRepository.findByNameAndKey_Project(aliasName, project)
                 .map(aliasMapper::mapToD);
     }
 }

--- a/src/main/java/apps/amaralus/qa/platform/mapper/dataset/AliasMapper.java
+++ b/src/main/java/apps/amaralus/qa/platform/mapper/dataset/AliasMapper.java
@@ -4,8 +4,19 @@ import apps.amaralus.qa.platform.dataset.dto.Alias;
 import apps.amaralus.qa.platform.dataset.model.AliasModel;
 import apps.amaralus.qa.platform.mapper.GenericMapper;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
 public interface AliasMapper extends GenericMapper<Alias, AliasModel> {
+
+    @Override
+    @Mapping(target = "key.id", source = "id")
+    @Mapping(target = "key.project", source = "project")
+    AliasModel mapToM(Alias alias);
+
+    @Override
+    @Mapping(target = "id", source = "key.id")
+    @Mapping(target = "project", source = "key.project")
+    Alias mapToD(AliasModel aliasModel);
 }

--- a/src/main/java/apps/amaralus/qa/platform/rocksdb/key/CompoundKey.java
+++ b/src/main/java/apps/amaralus/qa/platform/rocksdb/key/CompoundKey.java
@@ -1,0 +1,12 @@
+package apps.amaralus.qa.platform.rocksdb.key;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = TYPE)
+public @interface CompoundKey {
+}

--- a/src/main/java/apps/amaralus/qa/platform/rocksdb/sequence/AutoIncrementSequenceAspect.java
+++ b/src/main/java/apps/amaralus/qa/platform/rocksdb/sequence/AutoIncrementSequenceAspect.java
@@ -1,14 +1,18 @@
 package apps.amaralus.qa.platform.rocksdb.sequence;
 
+import apps.amaralus.qa.platform.rocksdb.key.CompoundKey;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.springframework.beans.InvalidPropertyException;
 import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.mapping.PersistentPropertyAccessor;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.stereotype.Component;
 
+import java.lang.reflect.Field;
 import java.util.Set;
 
 @Aspect
@@ -20,7 +24,8 @@ public class AutoIncrementSequenceAspect {
     private final MappingContext<?, ?> mappingContext;
     private final Set<Class<?>> sequences;
 
-    public AutoIncrementSequenceAspect(SequenceGenerator sequenceGenerator, MappingContext<?, ?> mappingContext) {
+    public AutoIncrementSequenceAspect(SequenceGenerator sequenceGenerator,
+                                       MappingContext<?, ?> mappingContext) {
         this.sequenceGenerator = sequenceGenerator;
         this.mappingContext = mappingContext;
         sequences = sequenceGenerator.getSequencesClasses();
@@ -52,19 +57,45 @@ public class AutoIncrementSequenceAspect {
         }
     }
 
+    @SneakyThrows
     @SuppressWarnings("java:S2589")
     private void incrementSequence(PersistentPropertyAccessor<?> accessor, PersistentProperty<?> persistentProperty) {
         var propertyValue = accessor.getProperty(persistentProperty);
-        // null or int or long equality
-        if (propertyValue == null || propertyValue.equals(0) || propertyValue.equals(0L)) {
-            long nextValue = sequenceGenerator.increment(getSequenceName(persistentProperty));
 
-            // possible int casting
-            if (persistentProperty.getType().equals(Integer.class)
-                    || persistentProperty.getType().equals(Integer.TYPE))
-                accessor.setProperty(persistentProperty, (int) nextValue);
-            else
-                accessor.setProperty(persistentProperty, nextValue);
+
+        if (propertyValue != null && propertyValue.getClass().isAnnotationPresent(CompoundKey.class)) {
+            incrementCompoundKey(persistentProperty, propertyValue);
+        } else {
+            if (propertyValue == null || propertyValue.equals(0) || propertyValue.equals(0L)) {
+                long nextValue = sequenceGenerator.increment(getSequenceName(persistentProperty));
+
+                // possible int casting
+                if (persistentProperty.getType().equals(Integer.class)
+                        || persistentProperty.getType().equals(Integer.TYPE))
+                    accessor.setProperty(persistentProperty, (int) nextValue);
+                else
+                    accessor.setProperty(persistentProperty, nextValue);
+            }
+        }
+    }
+
+    @SuppressWarnings("java:S3011")
+    private void incrementCompoundKey(PersistentProperty<?> persistentProperty, Object propertyValue) throws IllegalAccessException {
+
+        for (Field field : propertyValue.getClass().getDeclaredFields()) {
+
+            if (!field.getType().equals(Long.class)
+                    && !field.getType().equals(Long.TYPE)
+                    && !field.getType().equals(Integer.class)
+                    && !field.getType().equals(Integer.TYPE))
+                throw new InvalidPropertyException(persistentProperty.getOwner().getType(), persistentProperty.getName(), "Sequence only supports long or integer types");
+
+            field.setAccessible(true);
+
+            field.set(
+                    propertyValue,
+                    sequenceGenerator.increment(getSequenceName(persistentProperty))
+            );
         }
     }
 

--- a/src/main/java/apps/amaralus/qa/platform/rocksdb/sequence/SequenceGenerator.java
+++ b/src/main/java/apps/amaralus/qa/platform/rocksdb/sequence/SequenceGenerator.java
@@ -1,6 +1,7 @@
 package apps.amaralus.qa.platform.rocksdb.sequence;
 
 import apps.amaralus.qa.platform.rocksdb.RocksDbKeyValueAdapter;
+import apps.amaralus.qa.platform.rocksdb.key.CompoundKey;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.InvalidPropertyException;
 import org.springframework.data.mapping.PersistentProperty;
@@ -115,7 +116,8 @@ public class SequenceGenerator {
         if (!propertyType.equals(Long.class)
                 && !propertyType.equals(Long.TYPE)
                 && !propertyType.equals(Integer.class)
-                && !propertyType.equals(Integer.TYPE))
+                && !propertyType.equals(Integer.TYPE)
+                && !propertyType.isAnnotationPresent(CompoundKey.class))
             throw new InvalidPropertyException(sequenceClass, persistentProperty.getName(), "Sequence only supports long or integer types");
     }
 


### PR DESCRIPTION
Пример:
```
@Data
@KeySpace("alias")
public class AliasModel {

    @Id
    @GeneratedSequence("alias-sequence")
    private Key key;
    private String name;
    private long dataset;
    private String propertyName;

    @Getter
    @Setter
    @CompoundKey
    public static final class Key {
        long id;
        String project;
    }
}
```
составной ключ с генерацией long id

при сохранении в бд
```
    @Test
    void successfulSavingAliasWithAutoGenId() {
        Alias alias = new Alias(0, "NAME", 1L, "some", "some project");
        AliasModel aliasModel = mapper.mapToM(alias);
        aliasRepository.save(aliasModel);

        List<AliasModel> project = aliasRepository.findAll();

        project.forEach(System.out::println);

    }
```

поле id будет автоинкрементиться